### PR TITLE
Update SBT and Spark to new versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: scala
+scala:
+  - 2.10.6
+  - 2.11.7
+  - 2.12.0
+jdk:
+  - oraclejdk8
+  - oraclejdk7
+  - openjdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: scala
 scala:
   - 2.10.6
   - 2.11.7
-  - 2.12.0
 jdk:
   - oraclejdk8
   - oraclejdk7

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,9 @@ object Dependencies {
   object Compile {
     val spark = "org.apache.spark" %% "spark-mllib" % "2.0.1" % "provided"
     val breeze_natives = "org.scalanlp" %% "breeze-natives" % "0.11.2" % "provided"
-    val logging = "com.typesafe.scala-logging" %% "scala-logging" % "3.4.0"
+    val logging = Seq(
+      "org.slf4j" % "slf4j-api" % "1.7.16",
+      "org.slf4j" % "slf4j-log4j12" % "1.7.16")
 
     object Test {
       val scalatest = "org.scalatest" %% "scalatest" % "3.0.0" % "test"
@@ -20,5 +22,5 @@ object Dependencies {
   import Compile._
   val l = libraryDependencies
 
-  val core = l ++= Seq(spark, breeze_natives, logging, Test.scalatest)
+  val core = l ++= Seq(spark, breeze_natives, Test.scalatest) ++ logging
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,21 +3,22 @@ import Keys._
 
 object Dependencies {
   val Versions = Seq(
-    crossScalaVersions := Seq("2.10.5", "2.11.6"),
+    crossScalaVersions := Seq("2.11.8", "2.10.5"),
     scalaVersion := crossScalaVersions.value.head
   )
 
   object Compile {
-    val spark = "org.apache.spark" %% "spark-mllib" % "1.5.0" % "provided"
+    val spark = "org.apache.spark" %% "spark-mllib" % "2.0.1" % "provided"
     val breeze_natives = "org.scalanlp" %% "breeze-natives" % "0.11.2" % "provided"
+    val logging = "com.typesafe.scala-logging" %% "scala-logging" % "3.4.0"
 
     object Test {
-      val scalatest = "org.scalatest" %% "scalatest" % "2.2.4" % "test"
+      val scalatest = "org.scalatest" %% "scalatest" % "3.0.0" % "test"
     }
   }
 
   import Compile._
   val l = libraryDependencies
 
-  val core = l ++= Seq(spark, breeze_natives, Test.scalatest)
+  val core = l ++= Seq(spark, breeze_natives, logging, Test.scalatest)
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.13

--- a/spark-tsne-core/src/main/scala/com/github/saurfang/spark/tsne/TSNEGradient.scala
+++ b/spark-tsne-core/src/main/scala/com/github/saurfang/spark/tsne/TSNEGradient.scala
@@ -2,16 +2,17 @@ package com.github.saurfang.spark.tsne
 
 import breeze.linalg._
 import breeze.numerics._
+import com.typesafe.scalalogging.LazyLogging
 import com.github.saurfang.spark.tsne.tree.SPTree
-import org.apache.spark.Logging
 
-object TSNEGradient extends Logging  {
+object TSNEGradient extends LazyLogging {
   /**
-   *
-   * @param idx
-   * @param Y
-   * @return
-   */
+    * Compute the numerator from the matrix Y
+    *
+    * @param idx the index in the matrix to use.
+    * @param Y the matrix to analyze
+    * @return the numerator
+    */
   def computeNumerator(Y: DenseMatrix[Double], idx: Int *): DenseMatrix[Double] = {
     // Y_sum = ||Y_i||^2
     val sumY = sum(pow(Y, 2).apply(*, ::)) // n * 1
@@ -20,7 +21,7 @@ object TSNEGradient extends Logging  {
     val num: DenseMatrix[Double] = (y1(::, *) + sumY).t // k * n
     num := 1.0 :/ (1.0 :+ (num(::, *) + sumY(idx).toDenseVector)) // k * n
 
-    idx.indices.foreach(i => num.unsafeUpdate(i, idx(i), 0.0)) // num(i, i) = 0
+    idx.indices.foreach(i => num.update(i, idx(i), 0.0)) // num(i, i) = 0
 
     num
   }
@@ -43,7 +44,7 @@ object TSNEGradient extends Logging  {
                exaggeration: Boolean): Double = {
     // q = (1 + ||Y_i - Y_j||^2)^-1 / sum(1 + ||Y_k - Y_l||^2)^-1
     val q: DenseMatrix[Double] = num / totalNum
-    q.foreachPair{case ((i, j), v) => q.unsafeUpdate(i, j, math.max(v, 1e-12))}
+    q.foreachPair{case ((i, j), v) => q.update(i, j, math.max(v, 1e-12))}
 
     // q = q - p
     val loss = data.zipWithIndex.flatMap {
@@ -53,7 +54,7 @@ object TSNEGradient extends Logging  {
             val exaggeratedP = if(exaggeration) p * 4 else p
             val qij = q(i, j)
             val l = exaggeratedP * math.log(exaggeratedP / qij)
-            q.unsafeUpdate(i, j,  qij - exaggeratedP)
+            q.update(i, j,  qij - exaggeratedP)
             if(l.isNaN) 0.0 else l
         }
     }.sum
@@ -61,7 +62,7 @@ object TSNEGradient extends Logging  {
     // l = [ (p_ij - q_ij) * (1 + ||Y_i - Y_j||^2)^-1 ]
     q :*= -num
     // l_sum = [0 0 ... sum(l) ... 0]
-    sum(q(*, ::)).foreachPair{ case (i, v) => q.unsafeUpdate(i, data(i)._1, q(i, data(i)._1) - v) }
+    sum(q(*, ::)).foreachPair{ case (i, v) => q.update(i, data(i)._1, q(i, data(i)._1) - v) }
 
     // dY_i = -4 * (l - l_sum) * Y
     val dYi: DenseMatrix[Double] = -4.0 :* (q * Y)

--- a/spark-tsne-core/src/main/scala/com/github/saurfang/spark/tsne/TSNEGradient.scala
+++ b/spark-tsne-core/src/main/scala/com/github/saurfang/spark/tsne/TSNEGradient.scala
@@ -2,10 +2,12 @@ package com.github.saurfang.spark.tsne
 
 import breeze.linalg._
 import breeze.numerics._
-import com.typesafe.scalalogging.LazyLogging
 import com.github.saurfang.spark.tsne.tree.SPTree
+import org.slf4j.LoggerFactory
 
-object TSNEGradient extends LazyLogging {
+object TSNEGradient {
+  def logger = LoggerFactory.getLogger(TSNEGradient.getClass)
+
   /**
     * Compute the numerator from the matrix Y
     *

--- a/spark-tsne-core/src/main/scala/com/github/saurfang/spark/tsne/X2P.scala
+++ b/spark-tsne-core/src/main/scala/com/github/saurfang/spark/tsne/X2P.scala
@@ -1,13 +1,13 @@
 package com.github.saurfang.spark.tsne
 
 import breeze.linalg.DenseVector
-import org.apache.spark.Logging
+import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.mllib.X2PHelper._
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.mllib.linalg.distributed.{CoordinateMatrix, MatrixEntry, RowMatrix}
 import org.apache.spark.mllib.rdd.MLPairRDDFunctions._
 
-object X2P extends Logging {
+object X2P extends LazyLogging {
   def apply(x: RowMatrix, tol: Double = 1e-5, perplexity: Double = 30.0): CoordinateMatrix = {
     require(tol >= 0, "Tolerance must be non-negative")
     require(perplexity > 0, "Perplexity must be positive")
@@ -66,7 +66,7 @@ object X2P extends Logging {
           (arr.map(_._1).zip(p.toArray).map { case (j, v) => MatrixEntry(i, j, v) }, beta)
       }
 
-    logInfo("Mean value of sigma: " + p_betas.map(x => math.sqrt(1 / x._2)).mean)
+    logger.info("Mean value of sigma: " + p_betas.map(x => math.sqrt(1 / x._2)).mean)
     new CoordinateMatrix(p_betas.flatMap(_._1))
   }
 }

--- a/spark-tsne-core/src/main/scala/com/github/saurfang/spark/tsne/X2P.scala
+++ b/spark-tsne-core/src/main/scala/com/github/saurfang/spark/tsne/X2P.scala
@@ -1,13 +1,16 @@
 package com.github.saurfang.spark.tsne
 
 import breeze.linalg.DenseVector
-import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.mllib.X2PHelper._
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.mllib.linalg.distributed.{CoordinateMatrix, MatrixEntry, RowMatrix}
 import org.apache.spark.mllib.rdd.MLPairRDDFunctions._
+import org.slf4j.LoggerFactory
 
-object X2P extends LazyLogging {
+object X2P {
+
+  private def logger = LoggerFactory.getLogger(X2P.getClass)
+
   def apply(x: RowMatrix, tol: Double = 1e-5, perplexity: Double = 30.0): CoordinateMatrix = {
     require(tol >= 0, "Tolerance must be non-negative")
     require(perplexity > 0, "Perplexity must be positive")

--- a/spark-tsne-core/src/main/scala/com/github/saurfang/spark/tsne/impl/BHTSNE.scala
+++ b/spark-tsne-core/src/main/scala/com/github/saurfang/spark/tsne/impl/BHTSNE.scala
@@ -4,13 +4,15 @@ import breeze.linalg._
 import breeze.stats.distributions.Rand
 import com.github.saurfang.spark.tsne.tree.SPTree
 import com.github.saurfang.spark.tsne.{TSNEGradient, TSNEHelper, TSNEParam, X2P}
-import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.mllib.linalg.distributed.RowMatrix
 import org.apache.spark.storage.StorageLevel
+import org.slf4j.LoggerFactory
 
 import scala.util.Random
 
-object BHTSNE extends LazyLogging {
+object BHTSNE {
+  private def logger = LoggerFactory.getLogger(BHTSNE.getClass)
+
   def tsne(
             input: RowMatrix,
             noDims: Int = 2,

--- a/spark-tsne-core/src/main/scala/com/github/saurfang/spark/tsne/impl/LBFGSTSNE.scala
+++ b/spark-tsne-core/src/main/scala/com/github/saurfang/spark/tsne/impl/LBFGSTSNE.scala
@@ -4,7 +4,7 @@ import breeze.linalg._
 import breeze.optimize.{CachedDiffFunction, DiffFunction, LBFGS}
 import breeze.stats.distributions.Rand
 import com.github.saurfang.spark.tsne.{TSNEGradient, X2P}
-import org.apache.spark.Logging
+import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.mllib.linalg.distributed.RowMatrix
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
@@ -14,7 +14,7 @@ import scala.util.Random
 /**
  * TODO: This doesn't work at all (yet or ever).
  */
-object LBFGSTSNE extends Logging {
+object LBFGSTSNE extends LazyLogging {
   def tsne(
             input: RowMatrix,
             noDims: Int = 2,
@@ -24,7 +24,7 @@ object LBFGSTSNE extends Logging {
             perplexity: Double = 30,
             seed: Long = Random.nextLong()): DenseMatrix[Double] = {
     if(input.rows.getStorageLevel == StorageLevel.NONE) {
-      logWarning("Input is not persisted and performance could be bad")
+      logger.warn("Input is not persisted and performance could be bad")
     }
 
     Rand.generator.setSeed(seed)
@@ -64,7 +64,7 @@ object LBFGSTSNE extends Logging {
           val state = states.next()
           val loss = state.value
           //logInfo(state.convergedReason.get.toString)
-          logDebug(s"Iteration $iteration finished with $loss")
+          logger.debug(s"Iteration $iteration finished with $loss")
 
           Y := asDenseMatrix(state.x, n, noDims)
           //subscriber.onNext((iteration, Y.copy, Some(loss)))
@@ -81,7 +81,7 @@ object LBFGSTSNE extends Logging {
           val state = states.next()
           val loss = state.value
           //logInfo(state.convergedReason.get.toString)
-          logDebug(s"Iteration $iteration finished with $loss")
+          logger.debug(s"Iteration $iteration finished with $loss")
 
           Y := asDenseMatrix(state.x, n, noDims)
           //subscriber.onNext((iteration, Y.copy, Some(loss)))

--- a/spark-tsne-core/src/main/scala/com/github/saurfang/spark/tsne/impl/LBFGSTSNE.scala
+++ b/spark-tsne-core/src/main/scala/com/github/saurfang/spark/tsne/impl/LBFGSTSNE.scala
@@ -4,17 +4,19 @@ import breeze.linalg._
 import breeze.optimize.{CachedDiffFunction, DiffFunction, LBFGS}
 import breeze.stats.distributions.Rand
 import com.github.saurfang.spark.tsne.{TSNEGradient, X2P}
-import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.mllib.linalg.distributed.RowMatrix
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
+import org.slf4j.LoggerFactory
 
 import scala.util.Random
 
 /**
  * TODO: This doesn't work at all (yet or ever).
  */
-object LBFGSTSNE extends LazyLogging {
+object LBFGSTSNE {
+  private def logger = LoggerFactory.getLogger(LBFGSTSNE.getClass)
+
   def tsne(
             input: RowMatrix,
             noDims: Int = 2,

--- a/spark-tsne-core/src/main/scala/com/github/saurfang/spark/tsne/impl/SimpleTSNE.scala
+++ b/spark-tsne-core/src/main/scala/com/github/saurfang/spark/tsne/impl/SimpleTSNE.scala
@@ -3,13 +3,15 @@ package com.github.saurfang.spark.tsne.impl
 import breeze.linalg._
 import breeze.stats.distributions.Rand
 import com.github.saurfang.spark.tsne.{TSNEGradient, TSNEHelper, TSNEParam, X2P}
-import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.mllib.linalg.distributed.RowMatrix
 import org.apache.spark.storage.StorageLevel
+import org.slf4j.LoggerFactory
 
 import scala.util.Random
 
-object SimpleTSNE extends LazyLogging {
+object SimpleTSNE {
+  private def logger = LoggerFactory.getLogger(SimpleTSNE.getClass)
+
   def tsne(
             input: RowMatrix,
             noDims: Int = 2,

--- a/spark-tsne-core/src/main/scala/com/github/saurfang/spark/tsne/impl/SimpleTSNE.scala
+++ b/spark-tsne-core/src/main/scala/com/github/saurfang/spark/tsne/impl/SimpleTSNE.scala
@@ -1,16 +1,15 @@
 package com.github.saurfang.spark.tsne.impl
 
 import breeze.linalg._
-import breeze.stats._
 import breeze.stats.distributions.Rand
 import com.github.saurfang.spark.tsne.{TSNEGradient, TSNEHelper, TSNEParam, X2P}
-import org.apache.spark.Logging
+import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.mllib.linalg.distributed.RowMatrix
 import org.apache.spark.storage.StorageLevel
 
 import scala.util.Random
 
-object SimpleTSNE extends Logging {
+object SimpleTSNE extends LazyLogging {
   def tsne(
             input: RowMatrix,
             noDims: Int = 2,
@@ -19,7 +18,7 @@ object SimpleTSNE extends Logging {
             callback: (Int, DenseMatrix[Double], Option[Double]) => Unit = {case _ => },
             seed: Long = Random.nextLong()): DenseMatrix[Double] = {
     if(input.rows.getStorageLevel == StorageLevel.NONE) {
-      logWarning("Input is not persisted and performance could be bad")
+      logger.warn("Input is not persisted and performance could be bad")
     }
 
     Rand.generator.setSeed(seed)
@@ -62,7 +61,7 @@ object SimpleTSNE extends Logging {
 
         TSNEHelper.update(Y, dY, iY, gains, iteration, tsneParam)
 
-        logDebug(s"Iteration $iteration finished with $loss")
+        logger.debug(s"Iteration $iteration finished with $loss")
         callback(iteration, Y.copy, Some(loss))
         iteration += 1
       }

--- a/spark-tsne-core/src/test/scala/com/github/saurfang/spark/tsne/TSNEGradientTest.scala
+++ b/spark-tsne-core/src/test/scala/com/github/saurfang/spark/tsne/TSNEGradientTest.scala
@@ -1,8 +1,7 @@
 package com.github.saurfang.spark.tsne
 
-import org.scalatest.{Matchers, FunSuite}
 import breeze.linalg._
-import breeze.numerics._
+import org.scalatest.{FunSuite, Matchers}
 
 /**
  * Created by forest on 7/17/15.
@@ -10,6 +9,7 @@ import breeze.numerics._
 class TSNEGradientTest extends FunSuite with Matchers {
   test("computeNumerator should compute numerator for sub indices") {
     val Y = DenseMatrix.create(3, 2, (1 to 6).map(_.toDouble).toArray)
+    println(Y)
     val num = TSNEGradient.computeNumerator(Y, 0, 2)
     println(num)
   }

--- a/spark-tsne-examples/src/main/scala/com/github/saurfang/spark/tsne/examples/MNIST.scala
+++ b/spark-tsne-examples/src/main/scala/com/github/saurfang/spark/tsne/examples/MNIST.scala
@@ -1,17 +1,17 @@
 package com.github.saurfang.spark.tsne.examples
 
 
-import java.io.{OutputStreamWriter, BufferedWriter}
+import java.io.{BufferedWriter, OutputStreamWriter}
 
 import com.github.saurfang.spark.tsne.impl._
 import com.github.saurfang.spark.tsne.tree.SPTree
-import org.apache.hadoop.fs.{Path, FileSystem}
-import org.apache.spark.mllib.feature.StandardScaler
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.mllib.linalg.distributed.RowMatrix
-import org.apache.spark.{Logging, SparkConf, SparkContext}
+import org.apache.spark.{SparkConf, SparkContext}
 
-object MNIST extends Logging {
+object MNIST extends LazyLogging {
   def main (args: Array[String]) {
     val conf = new SparkConf()
       .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
@@ -51,7 +51,7 @@ object MNIST extends Logging {
     BHTSNE.tsne(pcaMatrix, maxIterations = 500, callback = {
     //LBFGSTSNE.tsne(pcaMatrix, perplexity = 10, maxNumIterations = 500, numCorrections = 10, convergenceTol = 1e-8)
       case (i, y, loss) =>
-        if(loss.isDefined) logInfo(s"$i iteration finished with loss $loss")
+        if(loss.isDefined) logger.info(s"$i iteration finished with loss $loss")
 
         val os = fs.create(new Path(s".tmp/MNIST/result${"%05d".format(i)}.csv"), true)
         val writer = new BufferedWriter(new OutputStreamWriter(os))

--- a/spark-tsne-examples/src/main/scala/com/github/saurfang/spark/tsne/examples/MNIST.scala
+++ b/spark-tsne-examples/src/main/scala/com/github/saurfang/spark/tsne/examples/MNIST.scala
@@ -5,13 +5,15 @@ import java.io.{BufferedWriter, OutputStreamWriter}
 
 import com.github.saurfang.spark.tsne.impl._
 import com.github.saurfang.spark.tsne.tree.SPTree
-import com.typesafe.scalalogging.LazyLogging
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.mllib.linalg.distributed.RowMatrix
 import org.apache.spark.{SparkConf, SparkContext}
+import org.slf4j.LoggerFactory
 
-object MNIST extends LazyLogging {
+object MNIST {
+  private def logger = LoggerFactory.getLogger(MNIST.getClass)
+
   def main (args: Array[String]) {
     val conf = new SparkConf()
       .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")


### PR DESCRIPTION
- SBT to 0.13.13
- Spark to 2.0.1

This allows restructuring the tSNE to be usable in a pipeline.